### PR TITLE
Fixes ArrowIcon function name and implements use of style props.

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -313,13 +313,13 @@ var number$2 = propTypes.number,
     oneOfType$2 = propTypes.oneOfType;
 
 
-SearchIcon$1.propTypes = {
+ArrowIcon.propTypes = {
   width: oneOfType$2([number$2, string$2]),
   height: oneOfType$2([number$2, string$2]),
   style: object$2
 };
 
-function SearchIcon$1(_ref) {
+function ArrowIcon(_ref) {
   var _ref$width = _ref.width,
       _ref$height = _ref.height,
       _ref$style = _ref.style;
@@ -1421,7 +1421,7 @@ function Photo(_ref8) {
             borderRadius: borderRadius - 1
           }
         },
-        React.createElement(SearchIcon$1, { width: 10, height: 10 })
+        React.createElement(ArrowIcon, { width: 10, height: 10 })
       )
     )
   );

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -307,13 +307,13 @@ var number$2 = propTypes.number,
     oneOfType$2 = propTypes.oneOfType;
 
 
-SearchIcon$1.propTypes = {
+ArrowIcon.propTypes = {
   width: oneOfType$2([number$2, string$2]),
   height: oneOfType$2([number$2, string$2]),
   style: object$2
 };
 
-function SearchIcon$1(_ref) {
+function ArrowIcon(_ref) {
   var _ref$width = _ref.width,
       _ref$height = _ref.height,
       _ref$style = _ref.style;
@@ -1415,7 +1415,7 @@ function Photo(_ref8) {
             borderRadius: borderRadius - 1
           }
         },
-        React.createElement(SearchIcon$1, { width: 10, height: 10 })
+        React.createElement(ArrowIcon, { width: 10, height: 10 })
       )
     )
   );

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -3083,13 +3083,13 @@
 	    oneOfType$2 = propTypes.oneOfType;
 
 
-	SearchIcon$1.propTypes = {
+	ArrowIcon.propTypes = {
 	  width: oneOfType$2([number$2, string$2]),
 	  height: oneOfType$2([number$2, string$2]),
 	  style: object$2
 	};
 
-	function SearchIcon$1(_ref) {
+	function ArrowIcon(_ref) {
 	  var _ref$width = _ref.width,
 	      _ref$height = _ref.height,
 	      _ref$style = _ref.style;
@@ -4901,7 +4901,7 @@
 	            borderRadius: borderRadius - 1
 	          }
 	        },
-	        react.createElement(SearchIcon$1, { width: 10, height: 10 })
+	        react.createElement(ArrowIcon, { width: 10, height: 10 })
 	      )
 	    )
 	  );

--- a/src/arrow_icon.js
+++ b/src/arrow_icon.js
@@ -2,15 +2,15 @@ import React from "react"
 import propTypes from "prop-types"
 const { number, object, string, oneOfType } = propTypes
 
-SearchIcon.propTypes = {
+ArrowIcon.propTypes = {
   width: oneOfType([number, string]),
   height: oneOfType([number, string]),
   style: object,
 }
 
-export default function SearchIcon({ width = 32, height = 32, style = {} }) {
+export default function ArrowIcon({ width = 32, height = 32, style = {} }) {
   return (
-    <svg width="14px" height="14px" viewBox="0 0 14 14">
+    <svg width={width} height={height} style={style} viewBox="0 0 14 14">
       <g>
       	<polygon style={{ fill: "currentColor" }} points="4,10.9 8.8,6 8.8,8.5 10.3,8.5 10.3,3.5 5.3,3.5 5.3,5 7.8,5 2.9,9.8 	"/>
       	<path style={{ fill: "currentColor" }} d="M13,0H1C0.4,0,0,0.4,0,1v12c0,0.6,0.4,1,1,1h12c0.6,0,1-0.4,1-1V1C14,0.4,13.6,0,13,0z M12.5,12.5h-11v-11h11V12.5z"/>

--- a/src/index.js
+++ b/src/index.js
@@ -603,7 +603,7 @@ function Photo({
             borderRadius: borderRadius - 1,
           }}
         >
-          <ArrowIcon width={10} height={10} />
+          <ArrowIcon width={14} height={14} />
         </a>
       </div>
     </div>


### PR DESCRIPTION
Once again, nice work on the component!

I noticed that `ArrowIcon` hadn't been renamed after copy/paste from `SearchIcon` so I named the function properly and also implemented the props that were being passed in but not used. (`height`, `style`, & `width`)

On the assumption you wanted to have the icon at `14px` I also set the new size in `src/index.js`.

Let me know if there are any issues here.