### PR TITLE
Upgrade unsplash-js: 4.8.0 -> 5.0.0

### DIFF
--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -403,7 +403,8 @@
 	  return port !== 0;
 	};
 
-	var has = Object.prototype.hasOwnProperty;
+	var has = Object.prototype.hasOwnProperty
+	  , undef;
 
 	/**
 	 * Decode a URI encoded string.
@@ -428,15 +429,18 @@
 	    , result = {}
 	    , part;
 
-	  //
-	  // Little nifty parsing hack, leverage the fact that RegExp.exec increments
-	  // the lastIndex property so we can continue executing this loop until we've
-	  // parsed all results.
-	  //
-	  for (;
-	    part = parser.exec(query);
-	    result[decode$1(part[1])] = decode$1(part[2])
-	  );
+	  while (part = parser.exec(query)) {
+	    var key = decode$1(part[1])
+	      , value = decode$1(part[2]);
+
+	    //
+	    // Prevent overriding of existing properties. This ensures that build-in
+	    // methods like `toString` or __proto__ are not overriden by malicious
+	    // querystrings.
+	    //
+	    if (key in result) continue;
+	    result[key] = value;
+	  }
 
 	  return result;
 	}
@@ -452,16 +456,28 @@
 	function querystringify(obj, prefix) {
 	  prefix = prefix || '';
 
-	  var pairs = [];
+	  var pairs = []
+	    , value
+	    , key;
 
 	  //
 	  // Optionally prefix with a '?' if needed
 	  //
 	  if ('string' !== typeof prefix) prefix = '?';
 
-	  for (var key in obj) {
+	  for (key in obj) {
 	    if (has.call(obj, key)) {
-	      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(obj[key]));
+	      value = obj[key];
+
+	      //
+	      // Edge cases where we actually want to encode the value to an empty
+	      // string instead of the stringified value.
+	      //
+	      if (!value && (value === null || value === undef || isNaN(value))) {
+	        value = '';
+	      }
+
+	      pairs.push(encodeURIComponent(key) +'='+ encodeURIComponent(value));
 	    }
 	  }
 
@@ -497,6 +513,9 @@
 	var rules = [
 	  ['#', 'hash'],                        // Extract from the back.
 	  ['?', 'query'],                       // Extract from the back.
+	  function sanitize(address) {          // Sanitize what is left of the address
+	    return address.replace('\\', '/');
+	  },
 	  ['/', 'pathname'],                    // Extract from the back.
 	  ['@', 'auth', 1],                     // Extract from the front.
 	  [NaN, 'host', undefined, 1, 1],       // Set left over value.
@@ -524,19 +543,27 @@
 	 *
 	 * @param {Object|String} loc Optional default location object.
 	 * @returns {Object} lolcation object.
-	 * @api public
+	 * @public
 	 */
 	function lolcation(loc) {
-	  loc = loc || commonjsGlobal.location || {};
+	  var globalVar;
+
+	  if (typeof window !== 'undefined') globalVar = window;
+	  else if (typeof commonjsGlobal !== 'undefined') globalVar = commonjsGlobal;
+	  else if (typeof self !== 'undefined') globalVar = self;
+	  else globalVar = {};
+
+	  var location = globalVar.location || {};
+	  loc = loc || location;
 
 	  var finaldestination = {}
 	    , type = typeof loc
 	    , key;
 
 	  if ('blob:' === loc.protocol) {
-	    finaldestination = new URL(unescape(loc.pathname), {});
+	    finaldestination = new Url(unescape(loc.pathname), {});
 	  } else if ('string' === type) {
-	    finaldestination = new URL(loc, {});
+	    finaldestination = new Url(loc, {});
 	    for (key in ignore) delete finaldestination[key];
 	  } else if ('object' === type) {
 	    for (key in loc) {
@@ -565,7 +592,7 @@
 	 *
 	 * @param {String} address URL we want to extract from.
 	 * @return {ProtocolExtract} Extracted information.
-	 * @api private
+	 * @private
 	 */
 	function extractProtocol(address) {
 	  var match = protocolre.exec(address);
@@ -583,7 +610,7 @@
 	 * @param {String} relative Pathname of the relative URL.
 	 * @param {String} base Pathname of the base URL.
 	 * @return {String} Resolved pathname.
-	 * @api private
+	 * @private
 	 */
 	function resolve(relative, base) {
 	  var path = (base || '/').split('/').slice(0, -1).concat(relative.split('/'))
@@ -616,15 +643,18 @@
 	 * create an actual constructor as it's much more memory efficient and
 	 * faster and it pleases my OCD.
 	 *
+	 * It is worth noting that we should not use `URL` as class name to prevent
+	 * clashes with the global URL instance that got introduced in browsers.
+	 *
 	 * @constructor
 	 * @param {String} address URL we want to parse.
-	 * @param {Object|String} location Location defaults for relative paths.
-	 * @param {Boolean|Function} parser Parser for the query string.
-	 * @api public
+	 * @param {Object|String} [location] Location defaults for relative paths.
+	 * @param {Boolean|Function} [parser] Parser for the query string.
+	 * @private
 	 */
-	function URL(address, location, parser) {
-	  if (!(this instanceof URL)) {
-	    return new URL(address, location, parser);
+	function Url(address, location, parser) {
+	  if (!(this instanceof Url)) {
+	    return new Url(address, location, parser);
 	  }
 
 	  var relative, extracted, parse, instruction, index, key
@@ -666,10 +696,16 @@
 	  // When the authority component is absent the URL starts with a path
 	  // component.
 	  //
-	  if (!extracted.slashes) instructions[2] = [/(.*)/, 'pathname'];
+	  if (!extracted.slashes) instructions[3] = [/(.*)/, 'pathname'];
 
 	  for (; i < instructions.length; i++) {
 	    instruction = instructions[i];
+
+	    if (typeof instruction === 'function') {
+	      address = instruction(address);
+	      continue;
+	    }
+
 	    parse = instruction[0];
 	    key = instruction[1];
 
@@ -760,8 +796,8 @@
 	 *                               used to parse the query.
 	 *                               When setting the protocol, double slash will be
 	 *                               removed from the final url if it is true.
-	 * @returns {URL}
-	 * @api public
+	 * @returns {URL} URL instance for chaining.
+	 * @public
 	 */
 	function set(part, value, fn) {
 	  var url = this;
@@ -846,8 +882,8 @@
 	 * Transform the properties back in to a valid and full URL string.
 	 *
 	 * @param {Function} stringify Optional query stringify function.
-	 * @returns {String}
-	 * @api public
+	 * @returns {String} Compiled version of the URL.
+	 * @public
 	 */
 	function toString(stringify) {
 	  if (!stringify || 'function' !== typeof stringify) stringify = querystringify_1.stringify;
@@ -876,17 +912,17 @@
 	  return result;
 	}
 
-	URL.prototype = { set: set, toString: toString };
+	Url.prototype = { set: set, toString: toString };
 
 	//
 	// Expose the URL parser and some additional properties that might be useful for
 	// others or testing.
 	//
-	URL.extractProtocol = extractProtocol;
-	URL.location = lolcation;
-	URL.qs = querystringify_1;
+	Url.extractProtocol = extractProtocol;
+	Url.location = lolcation;
+	Url.qs = querystringify_1;
 
-	var urlParse = URL;
+	var urlParse = Url;
 
 	var utils = createCommonjsModule(function (module, exports) {
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prop-types": "^15.6.1",
     "react": ">=15",
     "react-svg-spinner": "^1.0.1",
-    "unsplash-js": "^4.8.0"
+    "unsplash-js": "^5.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3824,9 +3824,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
-querystringify@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+querystringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
+  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -4100,9 +4101,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requires-port@~1.0.0:
+requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -4751,14 +4753,15 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unsplash-js@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/unsplash-js/-/unsplash-js-4.8.0.tgz#8a5a8ccbdf39410ffb9fdd5f04ed2651ea644349"
+unsplash-js@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unsplash-js/-/unsplash-js-5.0.0.tgz#85bb29bff3d49220be3b335679433a0299365290"
+  integrity sha512-yPh4h0m4y0BbSjjNbn36O+8rDESIgxvElwZMwOrvsZpmbtFspwARMnrHyZ3JbAUw62ZmRxHajlsPqw55qo1iug==
   dependencies:
     form-urlencoded "1.2.0"
     lodash.get "4.4.2"
     querystring "0.2.0"
-    url-parse "1.2.0"
+    url-parse "1.4.4"
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -4794,12 +4797,13 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.2.0.tgz#3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986"
+url-parse@1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
+  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
   dependencies:
-    querystringify "~1.0.0"
-    requires-port "~1.0.0"
+    querystringify "^2.0.0"
+    requires-port "^1.0.0"
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
unsplash-js before version 5.0.0 uses a version of url-parse that is
vulnerable to SSRF, Open Redirect, and Bypass Authentication Protocol
(ref: https://nvd.nist.gov/vuln/detail/CVE-2018-3774). There isn't a
version of unsplash-js lower than version 5.0.0 that uses an updated
version of the url-parse package, necessitating a major version bump for
this package.