### PR TITLE
Upgrade unsplash-js to v7.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-react",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "Upload images from unsplash into your app",
   "source": "src/index.js",
   "main": "dist/index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prop-types": "^15.6.1",
     "react": ">=15",
     "react-svg-spinner": "^1.0.1",
-    "unsplash-js": "^5.0.0"
+    "unsplash-js": "^7.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,9 @@ export default class UnsplashPicker extends React.Component {
     const download = this.state.unsplash.downloadPhoto(photo)
 
     const downloadPromise = preferredSize
-      ? this.state.unsplash.getPhoto(photo.id, preferredSize).then(r => r.urls.custom)
+      ? this.state.unsplash.getPhoto(photo.id, preferredSize).then(
+        r => `${r.urls.raw}&w=${preferredSize.width}&h=${preferredSize.height}`,
+      )
       : download.then(r => r.url)
 
     return downloadPromise

--- a/src/unsplash_wrapper.js
+++ b/src/unsplash_wrapper.js
@@ -1,5 +1,4 @@
 import { createApi } from "unsplash-js"
-import { toJson } from "./utils"
 
 class ChaosMonkey {
   constructor(shouldDoAnything) {
@@ -28,26 +27,34 @@ export default class UnsplashWrapper {
     this.unsplash = createApi({ accessKey })
   }
 
-  listPhotos = (page, perPage, type = "popular") => {
-    return this.unsplash.photos.list(page, perPage, type).then(this.processResponse)
+  listPhotos = (page, perPage, orderBy = "popular") => {
+    return this.unsplash.photos.list({ page, perPage, orderBy }).
+      then(this.processResponse).
+      then(({ response }) => response.results)
   }
 
-  searchPhotos = (search, page, perPage) => {
-    return this.unsplash.search.photos(search, page, perPage).then(this.processResponse)
+  searchPhotos = (query, page, perPage) => {
+    return this.unsplash.search.getPhotos({ query, page, perPage }).
+      then(this.processResponse).
+      then(({ response }) => response)
   }
 
   getPhoto = (id, { width, height } = {}) => {
-    return this.unsplash.photos.getPhoto(id, width, height).then(this.processResponse)
+    return this.unsplash.photos.get({ photoId: id, width, height }).
+      then(this.processResponse).
+      then(({ response }) => response)
   }
 
   downloadPhoto = photo => {
-    return this.unsplash.photos.downloadPhoto(photo).then(this.processResponse)
+    return this.unsplash.photos.trackDownload({ downloadLocation: photo.links.download_location }).
+      then(this.processResponse).
+      then(({ response }) => response)
   }
 
   processResponse = incomingResponse => {
     const response = Promise.resolve(this.__debug_chaosMonkey.process(incomingResponse))
 
-    return response.then(this.handleErrors).then(toJson)
+    return response.then(this.handleErrors)
   }
 
   handleErrors(response) {

--- a/src/unsplash_wrapper.js
+++ b/src/unsplash_wrapper.js
@@ -1,4 +1,4 @@
-import Unsplash from "unsplash-js"
+import { createApi } from "unsplash-js"
 import { toJson } from "./utils"
 
 class ChaosMonkey {
@@ -25,11 +25,11 @@ class ChaosMonkey {
 export default class UnsplashWrapper {
   constructor({ accessKey, __debug_chaosMonkey = false }) {
     this.__debug_chaosMonkey = new ChaosMonkey(__debug_chaosMonkey)
-    this.unsplash = new Unsplash({ applicationId: accessKey })
+    this.unsplash = createApi({ accessKey })
   }
 
   listPhotos = (page, perPage, type = "popular") => {
-    return this.unsplash.photos.listPhotos(page, perPage, type).then(this.processResponse)
+    return this.unsplash.photos.list(page, perPage, type).then(this.processResponse)
   }
 
   searchPhotos = (search, page, perPage) => {
@@ -51,7 +51,7 @@ export default class UnsplashWrapper {
   }
 
   handleErrors(response) {
-    if (!response.ok) {
+    if (response.type !== "success") {
       const error = Error(response.statusText)
       error.status = response.status
       throw error

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,5 @@
 import React from "react"
 
-export function toJson(response) {
-  return response.response.results
-}
-
 export function debounce(wait, func) {
   let timeout = null
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import React from "react"
 
 export function toJson(response) {
-  return response.json()
+  return response.response.results
 }
 
 export function debounce(wait, func) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,11 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/content-type@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/content-type/-/content-type-1.1.3.tgz#3688bd77fc12f935548eef102a4e34c512b03a07"
+  integrity sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==
+
 "@types/estree@*", "@types/estree@0.0.38":
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
@@ -1398,6 +1403,11 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+content-type@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+
 conventional-changelog-angular@^1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz#b27f2b315c16d0a1f23eb181309d0e6a4698ea0f"
@@ -2140,10 +2150,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-form-urlencoded@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/form-urlencoded/-/form-urlencoded-1.2.0.tgz#16ce2cafa76d2e48b9e513ab723228aea5993396"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3120,10 +3126,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.get@4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
 lodash.template@^4.0.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
@@ -3826,15 +3828,6 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-
-querystringify@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.0.tgz#7ded8dfbf7879dcc60d0a644ac6754b283ad17ef"
-  integrity sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==
-
 quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
@@ -4107,11 +4100,6 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
-
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -4752,15 +4740,13 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unsplash-js@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/unsplash-js/-/unsplash-js-5.0.0.tgz#85bb29bff3d49220be3b335679433a0299365290"
-  integrity sha512-yPh4h0m4y0BbSjjNbn36O+8rDESIgxvElwZMwOrvsZpmbtFspwARMnrHyZ3JbAUw62ZmRxHajlsPqw55qo1iug==
+unsplash-js@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/unsplash-js/-/unsplash-js-7.0.4.tgz#bd9f59975f46137e0562652593a45f5df47acbb1"
+  integrity sha512-MEIeUxGKLxPIas55HStYvnL7EwNWFPhNZWObiMZf8iFFfNbwNCC/JT07nRf19u5yEN9xfWP7SH+ymcZe2GLFug==
   dependencies:
-    form-urlencoded "1.2.0"
-    lodash.get "4.4.2"
-    querystring "0.2.0"
-    url-parse "1.4.4"
+    "@types/content-type" "^1.1.3"
+    content-type "^1.0.4"
 
 unzip-response@^2.0.1:
   version "2.0.1"
@@ -4795,14 +4781,6 @@ url-parse-lax@^3.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
   dependencies:
     prepend-http "^2.0.0"
-
-url-parse@1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.4.tgz#cac1556e95faa0303691fec5cf9d5a1bc34648f8"
-  integrity sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==
-  dependencies:
-    querystringify "^2.0.0"
-    requires-port "^1.0.0"
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
This upgrades the `unsplash-js` dependency from v5.0.0 to v7.0.4. There have been a few [breaking changes from 5 ➡️ 6 and 6 ➡️ 7](https://github.com/unsplash/unsplash-js/blob/master/CHANGELOG.md) but we were able to maintain the same public API for both `UnsplashWrapper` and the `UnsplashPicker` React component.