### PR TITLE
Style fixes for image grid and input field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Upload images from unsplash into your app",
   "source": "src/index.js",
   "main": "dist/index.cjs.js",

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,6 @@ export default class UnsplashPicker extends React.Component {
                     key={photo.id}
                     photo={photo}
                     index={index}
-                    height={searchResultHeight}
                     columns={searchResultColumns}
                     loadingPhoto={loadingPhoto}
                     selectedPhoto={selectedPhoto}
@@ -535,7 +534,6 @@ Photo.propTypes = {
     }).isRequired,
     user: shape({ links: shape({ html: string.isRequired }).isRequired }).isRequired,
   }).isRequired,
-  height: number.isRequired,
   loadingPhoto: shape({ id: string.isRequired }),
   selectedPhoto: shape({ id: string.isRequired }),
   onPhotoClick: func.isRequired,
@@ -544,7 +542,6 @@ Photo.propTypes = {
 }
 function Photo({
   photo,
-  height,
   loadingPhoto,
   selectedPhoto,
   onPhotoClick,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const inputNoAppearanceStyle = {
   boxShadow: "none",
   fontSize: "1em",
   outline: "none",
+  height: "inherit",
 }
 
 const inputGray = "#AAA"
@@ -426,6 +427,9 @@ function CSSStyles() {
         .unsplash-react.h-f,
         .unsplash-react .h-f { height: 100%; }
 
+        .unsplash-react.ai-c,
+        .unsplash-react .ai-c { align-items: center; }
+
         .unsplash-react.border-radius,
         .unsplash-react .border-radius { border-radius: ${borderRadius}px; }
       `,
@@ -437,9 +441,9 @@ function CSSStyles() {
 SearchInputIcon.propTypes = { isLoading: bool.isRequired, hasError: bool.isRequired, style: object }
 function SearchInputIcon({ isLoading, hasError, style, ...rest }) {
   const searchColor = hasError ? "#D62828" : inputGray
-  const mergedStyle = { top: "0.15em", marginRight: ".5em", ...style }
+  const mergedStyle = { marginRight: ".5em", ...style }
   return (
-    <div className="p-r" style={mergedStyle} {...rest}>
+    <div className="p-r d-f ai-c" style={mergedStyle} {...rest}>
       {isLoading ? (
         <Spinner size="1em" color={searchColor} />
       ) : (

--- a/src/index.js
+++ b/src/index.js
@@ -333,7 +333,6 @@ export default class UnsplashPicker extends React.Component {
                     key={photo.id}
                     photo={photo}
                     index={index}
-                    width={searchResultWidth}
                     height={searchResultHeight}
                     columns={searchResultColumns}
                     loadingPhoto={loadingPhoto}

--- a/src/index.js
+++ b/src/index.js
@@ -332,12 +332,10 @@ export default class UnsplashPicker extends React.Component {
               </div>
             ) : (
               [
-                photos.map((photo, index) => (
+                photos.map(photo => (
                   <Photo
                     key={photo.id}
                     photo={photo}
-                    index={index}
-                    columns={searchResultColumns}
                     loadingPhoto={loadingPhoto}
                     selectedPhoto={selectedPhoto}
                     onPhotoClick={this.handlePhotoClick}

--- a/src/index.js
+++ b/src/index.js
@@ -314,8 +314,8 @@ export default class UnsplashPicker extends React.Component {
 
         <div className="p-r f-1 border-radius" style={{ marginTop: ".5em", overflow: "hidden" }}>
           <div
-            className="h-f"
-            style={{ overflowY: "scroll" }}
+            className="h-f unsplash-react__image-grid"
+            style={{ overflowY: "scroll", "--imageWidth": `${searchResultWidth}px` }}
             ref={element => (this.searchResults = element)}
           >
             {error ? (
@@ -432,6 +432,12 @@ function CSSStyles() {
 
         .unsplash-react.border-radius,
         .unsplash-react .border-radius { border-radius: ${borderRadius}px; }
+
+        .unsplash-react .unsplash-react__image-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(calc(var(--imageWidth) - 16px), 1fr));
+          gap: 12px;
+        }
       `,
       }}
     />
@@ -519,10 +525,7 @@ Photo.propTypes = {
     }).isRequired,
     user: shape({ links: shape({ html: string.isRequired }).isRequired }).isRequired,
   }).isRequired,
-  width: number.isRequired,
   height: number.isRequired,
-  index: number.isRequired,
-  columns: number.isRequired,
   loadingPhoto: shape({ id: string.isRequired }),
   selectedPhoto: shape({ id: string.isRequired }),
   onPhotoClick: func.isRequired,
@@ -531,17 +534,13 @@ Photo.propTypes = {
 }
 function Photo({
   photo,
-  width,
   height,
-  index,
-  columns,
   loadingPhoto,
   selectedPhoto,
   onPhotoClick,
   highlightColor,
   utmLink,
 }) {
-  const isFarLeft = index % columns === 0
   const loadingPhotoId = loadingPhoto && loadingPhoto.id
   const selectedPhotoId = selectedPhoto && selectedPhoto.id
   const isSelectedAndLoaded = loadingPhotoId === null && selectedPhotoId === photo.id
@@ -549,19 +548,7 @@ function Photo({
   const onClick = () => onPhotoClick(photo)
 
   return (
-    <div
-      style={{
-        display: "inline-block",
-        width,
-        marginTop: 0,
-        marginBottom: 12,
-        marginLeft: 0,
-        marginRight: 0,
-        paddingTop: ".5em",
-        paddingLeft: isFarLeft || ".5em",
-      }}
-      className="p-0"
-    >
+    <div>
       <div
         className="p-r border-radius"
         style={{

--- a/src/index.js
+++ b/src/index.js
@@ -315,7 +315,11 @@ export default class UnsplashPicker extends React.Component {
         <div className="p-r f-1 border-radius" style={{ marginTop: ".5em", overflow: "hidden" }}>
           <div
             className="h-f unsplash-react__image-grid"
-            style={{ overflowY: "scroll", "--imageWidth": `${searchResultWidth}px` }}
+            style={{
+              overflowY: "scroll",
+              "--imageWidth": `${searchResultWidth}px`,
+              "--imageHeight": `${searchResultHeight}px`,
+            }}
             ref={element => (this.searchResults = element)}
           >
             {error ? (

--- a/src/index.js
+++ b/src/index.js
@@ -441,6 +441,13 @@ function CSSStyles() {
           grid-template-columns: repeat(auto-fit, minmax(calc(var(--imageWidth) - 16px), 1fr));
           gap: 12px;
         }
+
+        .unsplash-react__image {
+          display: block;
+          width: 100%;
+          height: var(--imageHeight);
+          object-fit: cover;
+        }
       `,
       }}
     />
@@ -565,10 +572,6 @@ function Photo({
         <SpinnerImg
           src={photo.urls.small}
           style={{
-            display: "block",
-            width: "100%",
-            height,
-            objectFit: "cover",
             borderWidth,
             borderStyle: "solid",
             borderColor: isSelectedAndLoaded ? highlightColor : "transparent",

--- a/src/spinner_img.js
+++ b/src/spinner_img.js
@@ -38,6 +38,7 @@ export default class SpinnerImg extends React.Component {
         <img
           {...rest}
           src={this.state.loaded ? src : blank}
+          className="unsplash-react__image"
           style={{
             ...style,
             transition: `opacity .3s, ${style.transition}`,


### PR DESCRIPTION
## Goal 

This looks to fix two styling issues that seemed to have appeared recently. 

#### Issues:

1. The browser's overflow scrollbars are impeding the image grid and causing it to lose one of its columns with a space on the right. (3 columns become 2 and 2 columns become 1). 
2. Package's input takes on the height if a default height applied to input[type="text"] was set by the parent site.


#### Proposed Solutions:
1. Refactor the image's container to use CSS Grid and remove associated styling from the images. 
2. Assign a default `height: inherent` to the search input and center its icons with flex's `align-items` property.

(More details are in the commit's descriptions.)


## Preview 
| Before                                                                                                           | After                                                                                                           |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/29933355/139509333-fabd0a27-90a1-485e-8e97-3258fea0bd10.png) | ![After](https://user-images.githubusercontent.com/29933355/139509506-f4865547-914f-4143-a170-f8b2bcdb1032.png) |

