### PR TITLE
Add AfterAttribution prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unsplash-react",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Upload images from unsplash into your app",
   "source": "src/index.js",
   "main": "dist/index.cjs.js",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import ArrowIcon from "./arrow_icon"
 import SpinnerImg from "./spinner_img"
 import ReactIntersectionObserver from "./react_intersection_observer.js"
 import "intersection-observer"
-import { debounce, throttle, withDefaultProps } from "./utils"
+import { debounce, throttle, withDefaultProps, NullComponent } from "./utils"
 const { string, func, number, bool, object, shape } = propTypes
 
 import BlobUploader from "./uploaders/blob_uploader"
@@ -49,6 +49,7 @@ export default class UnsplashPicker extends React.Component {
     }),
     Uploader: func,
     __debug_chaosMonkey: bool,
+    AfterAttribution: func,
   }
 
   static defaultProps = {
@@ -60,6 +61,7 @@ export default class UnsplashPicker extends React.Component {
     preferredSize: null,
     Uploader: Base64Uploader,
     __debug_chaosMonkey: false,
+    AfterAttribution: NullComponent,
   }
 
   constructor(props) {
@@ -239,7 +241,13 @@ export default class UnsplashPicker extends React.Component {
   }
 
   render() {
-    const { Uploader, columns: searchResultColumns, photoRatio, highlightColor } = this.props
+    const {
+      AfterAttribution,
+      Uploader,
+      columns: searchResultColumns,
+      photoRatio,
+      highlightColor,
+    } = this.props
     const {
       photos,
       search,
@@ -264,24 +272,25 @@ export default class UnsplashPicker extends React.Component {
         className="unsplash-react d-f h-f p-0"
       >
         <CSSStyles />
-        <span
-          style={{
-            color: inputGray,
-            fontSize: 12,
-            textAlign: "center",
-            display: "block",
-            marginBottom: "1em",
-          }}
-        >
-          Photos provided by{" "}
-          <a
-            href={this.utmLink("https://unsplash.com/")}
-            target="_blank"
-            style={{ color: inputGray }}
+        <div style={{ textAlign: "center" }}>
+          <span
+            style={{
+              color: inputGray,
+              fontSize: 12,
+              marginBottom: "1em",
+            }}
           >
-            Unsplash
-          </a>
-        </span>
+            Photos provided by{" "}
+            <a
+              href={this.utmLink("https://unsplash.com/")}
+              target="_blank"
+              style={{ color: inputGray }}
+            >
+              Unsplash
+            </a>
+          </span>
+          <AfterAttribution />
+        </div>
         <div
           className="d-f"
           style={{

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,3 +37,7 @@ export function withDefaultProps(Component, defaultProps) {
 
   return WrappedComponent
 }
+
+export function NullComponent() {
+  return null
+}


### PR DESCRIPTION
We wanted to add a helper shelf after the `Photos provided by Unsplash` attribution.
Rather than hardcode something within this library, it seemed more flexible to add an optional prop called `AfterAttribution` to enable users to render a custom component there.

I adjusted some of the markup (enclosed the existing `span` in a `div` and moved some styles around) to facilitate adding this component in what seemed like a reasonable place.

Also, I bumped the version to `0.3.0`. This seemed bigger than a patch since it adds a new feature, but it's also not a breaking change because the prop has a default value to just render nothing.