### PR TITLE
chore: inline `Spinner` component from `react-svg-spinner`

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -7,7 +7,6 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var unsplashJs = require('unsplash-js');
 var React = _interopDefault(require('react'));
 var propTypes = _interopDefault(require('prop-types'));
-var Spinner = _interopDefault(require('react-svg-spinner'));
 require('intersection-observer');
 
 var classCallCheck = function (instance, Constructor) {
@@ -190,6 +189,73 @@ var UnsplashWrapper = function () {
   }]);
   return UnsplashWrapper;
 }();
+
+function speedSwitch(speed) {
+  if (speed === "fast") return 600;
+  if (speed === "slow") return 900;
+  return 750;
+}
+
+var Spinner = function Spinner(_ref) {
+  var color = _ref.color,
+      speed = _ref.speed,
+      gap = _ref.gap,
+      thickness = _ref.thickness,
+      size = _ref.size,
+      props = objectWithoutProperties(_ref, ["color", "speed", "gap", "thickness", "size"]);
+  return React.createElement(
+    "svg",
+    _extends({
+      height: size,
+      width: size
+    }, props, {
+      style: { animationDuration: speedSwitch(speed) + "ms" },
+      className: "__react-svg-spinner_circle",
+      role: "img",
+      "aria-labelledby": "title desc",
+      viewBox: "0 0 32 32"
+    }),
+    React.createElement(
+      "title",
+      { id: "title" },
+      "Circle loading spinner"
+    ),
+    React.createElement(
+      "desc",
+      { id: "desc" },
+      "Image of a partial circle indicating \"loading.\""
+    ),
+    React.createElement("style", {
+      dangerouslySetInnerHTML: {
+        __html: "\n      .__react-svg-spinner_circle{\n          transition-property: transform;\n          animation-name: __react-svg-spinner_infinite-spin;\n          animation-iteration-count: infinite;\n          animation-timing-function: linear;\n      }\n      @keyframes __react-svg-spinner_infinite-spin {\n          from {transform: rotate(0deg)}\n          to {transform: rotate(360deg)}\n      }\n    "
+      }
+    }),
+    React.createElement("circle", {
+      role: "presentation",
+      cx: 16,
+      cy: 16,
+      r: 14 - thickness / 2,
+      stroke: color,
+      fill: "none",
+      strokeWidth: thickness,
+      strokeDasharray: Math.PI * 2 * (11 - gap),
+      strokeLinecap: "round"
+    })
+  );
+};
+Spinner.propTypes = {
+  color: propTypes.string,
+  thickness: propTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]).isRequired,
+  gap: propTypes.oneOf([1, 2, 3, 4, 5]).isRequired,
+  speed: propTypes.oneOf(["fast", "slow"]),
+  size: propTypes.string.isRequired
+};
+Spinner.defaultProps = {
+  color: "rgba(0,0,0,0.4)",
+  gap: 4,
+  thickness: 4,
+  size: "1em"
+};
 
 var number = propTypes.number,
     object = propTypes.object,

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,7 +1,6 @@
 import { createApi } from 'unsplash-js';
 import React from 'react';
 import propTypes from 'prop-types';
-import Spinner from 'react-svg-spinner';
 import 'intersection-observer';
 
 var classCallCheck = function (instance, Constructor) {
@@ -184,6 +183,73 @@ var UnsplashWrapper = function () {
   }]);
   return UnsplashWrapper;
 }();
+
+function speedSwitch(speed) {
+  if (speed === "fast") return 600;
+  if (speed === "slow") return 900;
+  return 750;
+}
+
+var Spinner = function Spinner(_ref) {
+  var color = _ref.color,
+      speed = _ref.speed,
+      gap = _ref.gap,
+      thickness = _ref.thickness,
+      size = _ref.size,
+      props = objectWithoutProperties(_ref, ["color", "speed", "gap", "thickness", "size"]);
+  return React.createElement(
+    "svg",
+    _extends({
+      height: size,
+      width: size
+    }, props, {
+      style: { animationDuration: speedSwitch(speed) + "ms" },
+      className: "__react-svg-spinner_circle",
+      role: "img",
+      "aria-labelledby": "title desc",
+      viewBox: "0 0 32 32"
+    }),
+    React.createElement(
+      "title",
+      { id: "title" },
+      "Circle loading spinner"
+    ),
+    React.createElement(
+      "desc",
+      { id: "desc" },
+      "Image of a partial circle indicating \"loading.\""
+    ),
+    React.createElement("style", {
+      dangerouslySetInnerHTML: {
+        __html: "\n      .__react-svg-spinner_circle{\n          transition-property: transform;\n          animation-name: __react-svg-spinner_infinite-spin;\n          animation-iteration-count: infinite;\n          animation-timing-function: linear;\n      }\n      @keyframes __react-svg-spinner_infinite-spin {\n          from {transform: rotate(0deg)}\n          to {transform: rotate(360deg)}\n      }\n    "
+      }
+    }),
+    React.createElement("circle", {
+      role: "presentation",
+      cx: 16,
+      cy: 16,
+      r: 14 - thickness / 2,
+      stroke: color,
+      fill: "none",
+      strokeWidth: thickness,
+      strokeDasharray: Math.PI * 2 * (11 - gap),
+      strokeLinecap: "round"
+    })
+  );
+};
+Spinner.propTypes = {
+  color: propTypes.string,
+  thickness: propTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]).isRequired,
+  gap: propTypes.oneOf([1, 2, 3, 4, 5]).isRequired,
+  speed: propTypes.oneOf(["fast", "slow"]),
+  size: propTypes.string.isRequired
+};
+Spinner.defaultProps = {
+  color: "rgba(0,0,0,0.4)",
+  gap: 4,
+  thickness: 4,
+  size: "1em"
+};
 
 var number = propTypes.number,
     object = propTypes.object,

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -4,10 +4,6 @@
 	(factory((global.UnsplashReact = {})));
 }(this, (function (exports) { 'use strict';
 
-	function unwrapExports (x) {
-		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
-	}
-
 	function createCommonjsModule(fn, module) {
 		return module = { exports: {} }, fn(module, module.exports), module.exports;
 	}
@@ -1378,12 +1374,72 @@
 	}
 	});
 
-	var index_m = createCommonjsModule(function (module) {
-	var e=Object.assign||function(e){for(var t=arguments,n=1;n<arguments.length;n++){var r=t[n];for(var i in r)Object.prototype.hasOwnProperty.call(r,i)&&(e[i]=r[i]);}return e},t=r(react),n=r(propTypes);function r(e){return e&&e.__esModule?e:{default:e}}var i=function(n){var r=n.color,i=n.speed,a=n.gap,s=n.thickness,o=n.size,l=function(e,t){var n={};for(var r in e)t.indexOf(r)>=0||Object.prototype.hasOwnProperty.call(e,r)&&(n[r]=e[r]);return n}(n,["color","speed","gap","thickness","size"]);return t.default.createElement("svg",e({height:o,width:o},l,{style:{animationDuration:function(e){return"fast"===e?600:"slow"===e?900:750}(i)+"ms"},className:"__react-svg-spinner_circle",role:"img","aria-labelledby":"title desc",viewBox:"0 0 32 32"}),t.default.createElement("title",{id:"title"},"Circle loading spinner"),t.default.createElement("desc",{id:"desc"},'Image of a partial circle indicating "loading."'),t.default.createElement("style",{dangerouslySetInnerHTML:{__html:"\n      .__react-svg-spinner_circle{\n          transition-property: transform;\n          animation-name: __react-svg-spinner_infinite-spin;\n          animation-iteration-count: infinite;\n          animation-timing-function: linear;\n      }\n      @keyframes __react-svg-spinner_infinite-spin {\n          from {transform: rotate(0deg)}\n          to {transform: rotate(360deg)}\n      }\n    "}}),t.default.createElement("circle",{role:"presentation",cx:16,cy:16,r:14-s/2,stroke:r,fill:"none",strokeWidth:s,strokeDasharray:2*Math.PI*(11-a),strokeLinecap:"round"}))};i.propTypes={color:n.default.string,thickness:n.default.oneOf([1,2,3,4,5,6,7,8]).isRequired,gap:n.default.oneOf([1,2,3,4,5]).isRequired,speed:n.default.oneOf(["fast","slow"]),size:n.default.string.isRequired}, i.defaultProps={color:"rgba(0,0,0,0.4)",gap:4,thickness:4,size:"1em"}, module.exports=i;
+	function speedSwitch(speed) {
+	  if (speed === "fast") return 600;
+	  if (speed === "slow") return 900;
+	  return 750;
+	}
 
-	});
-
-	var Spinner = unwrapExports(index_m);
+	var Spinner = function Spinner(_ref) {
+	  var color = _ref.color,
+	      speed = _ref.speed,
+	      gap = _ref.gap,
+	      thickness = _ref.thickness,
+	      size = _ref.size,
+	      props = objectWithoutProperties(_ref, ["color", "speed", "gap", "thickness", "size"]);
+	  return react.createElement(
+	    "svg",
+	    _extends$1({
+	      height: size,
+	      width: size
+	    }, props, {
+	      style: { animationDuration: speedSwitch(speed) + "ms" },
+	      className: "__react-svg-spinner_circle",
+	      role: "img",
+	      "aria-labelledby": "title desc",
+	      viewBox: "0 0 32 32"
+	    }),
+	    react.createElement(
+	      "title",
+	      { id: "title" },
+	      "Circle loading spinner"
+	    ),
+	    react.createElement(
+	      "desc",
+	      { id: "desc" },
+	      "Image of a partial circle indicating \"loading.\""
+	    ),
+	    react.createElement("style", {
+	      dangerouslySetInnerHTML: {
+	        __html: "\n      .__react-svg-spinner_circle{\n          transition-property: transform;\n          animation-name: __react-svg-spinner_infinite-spin;\n          animation-iteration-count: infinite;\n          animation-timing-function: linear;\n      }\n      @keyframes __react-svg-spinner_infinite-spin {\n          from {transform: rotate(0deg)}\n          to {transform: rotate(360deg)}\n      }\n    "
+	      }
+	    }),
+	    react.createElement("circle", {
+	      role: "presentation",
+	      cx: 16,
+	      cy: 16,
+	      r: 14 - thickness / 2,
+	      stroke: color,
+	      fill: "none",
+	      strokeWidth: thickness,
+	      strokeDasharray: Math.PI * 2 * (11 - gap),
+	      strokeLinecap: "round"
+	    })
+	  );
+	};
+	Spinner.propTypes = {
+	  color: propTypes.string,
+	  thickness: propTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]).isRequired,
+	  gap: propTypes.oneOf([1, 2, 3, 4, 5]).isRequired,
+	  speed: propTypes.oneOf(["fast", "slow"]),
+	  size: propTypes.string.isRequired
+	};
+	Spinner.defaultProps = {
+	  color: "rgba(0,0,0,0.4)",
+	  gap: 4,
+	  thickness: 4,
+	  size: "1em"
+	};
 
 	var number = propTypes.number,
 	    object = propTypes.object,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "intersection-observer": "^0.5.0",
     "prop-types": "^15.6.1",
     "react": ">=15",
-    "react-svg-spinner": "^1.0.1",
     "unsplash-js": "^7.0.4"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import UnsplashWrapper from "./unsplash_wrapper"
-import Spinner from "react-svg-spinner"
+import Spinner from "./spinner"
 import propTypes from "prop-types"
 import SearchIcon from "./search_icon"
 import ErrorImage from "./error_image"

--- a/src/spinner.js
+++ b/src/spinner.js
@@ -1,0 +1,66 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+function speedSwitch(speed) {
+  if (speed === "fast") return 600
+  if (speed === "slow") return 900
+  return 750
+}
+
+const Spinner = ({ color, speed, gap, thickness, size, ...props }) => (
+  <svg
+    height={size}
+    width={size}
+    {...props}
+    style={{ animationDuration: `${speedSwitch(speed)}ms` }}
+    className="__react-svg-spinner_circle"
+    role="img"
+    aria-labelledby="title desc"
+    viewBox="0 0 32 32"
+  >
+    <title id="title">Circle loading spinner</title>
+    <desc id="desc">Image of a partial circle indicating "loading."</desc>
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+      .__react-svg-spinner_circle{
+          transition-property: transform;
+          animation-name: __react-svg-spinner_infinite-spin;
+          animation-iteration-count: infinite;
+          animation-timing-function: linear;
+      }
+      @keyframes __react-svg-spinner_infinite-spin {
+          from {transform: rotate(0deg)}
+          to {transform: rotate(360deg)}
+      }
+    `,
+      }}
+    />
+    <circle
+      role="presentation"
+      cx={16}
+      cy={16}
+      r={14 - thickness / 2}
+      stroke={color}
+      fill="none"
+      strokeWidth={thickness}
+      strokeDasharray={Math.PI * 2 * (11 - gap)}
+      strokeLinecap="round"
+    />
+  </svg>
+)
+Spinner.propTypes = {
+  color: PropTypes.string,
+  thickness: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8]).isRequired,
+  gap: PropTypes.oneOf([1, 2, 3, 4, 5]).isRequired,
+  speed: PropTypes.oneOf(["fast", "slow"]),
+  size: PropTypes.string.isRequired,
+}
+Spinner.defaultProps = {
+  color: "rgba(0,0,0,0.4)",
+  gap: 4,
+  thickness: 4,
+  size: "1em",
+}
+
+export default Spinner

--- a/src/spinner_img.js
+++ b/src/spinner_img.js
@@ -1,5 +1,5 @@
 import React from "react"
-import Spinner from "react-svg-spinner"
+import Spinner from "./spinner"
 import propTypes from "prop-types"
 const { string, object } = propTypes
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3858,14 +3858,7 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-svg-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-svg-spinner/-/react-svg-spinner-1.0.1.tgz#cdf39ad1c4e896081f9f82b9e7b799f3929386db"
-  dependencies:
-    prop-types "^15.6.0"
-    react ">= 15 < 17"
-
-"react@>= 15 < 17", react@>=15:
+react@>=15:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
   dependencies:


### PR DESCRIPTION
The latest released version of `react-svg-spinner` (`v1.0.4`) has a bad `umd:main` in the `package.json` that points to `dist/foo.mjs` instead of `dist/index.mjs` resulting in a bad export/import (specifically when using Vite).

As discussed, the package is so tiny that it's worth dropping the dependency to inline the Spinner component here.

I thought about bumping the version as well, but I thought you may want to handle versioning/releasing in your own manner. To that end, if I need to drop the `yarn run prepare` commit, just let me know.

Thanks!