### PR TITLE
fix: move react to peerDependencies and require >=16.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   "types": "dist/types/index.d.ts",
   "dependencies": {
     "intersection-observer": "^0.5.0",
-    "react": ">=15",
     "unsplash-js": "^7.0.4"
+  },
+  "peerDependencies": {
+    "react": ">=16.8"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",


### PR DESCRIPTION
## Summary

- Moves `react` from dependencies to peerDependencies (correct pattern for React component libraries)
- Updates minimum React version from `>=15` to `>=16.8` for React 18 compatibility

Fixes #32

## Test plan

- [x] Build succeeds with `npm run build`
- [ ] Verify library works correctly when installed as a dependency in a React 18 project

🤖 Generated with [Claude Code](https://claude.com/claude-code)