### PR TITLE
ci: use github PR style for release-please changelogs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "changelog-type": "github",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- Configure release-please to use "github" changelog type
- Changelog entries will now include PR numbers and contributor information

## Test plan
- [ ] Merge this PR and verify the next release-please PR generates changelog entries with PR links

🤖 Generated with [Claude Code](https://claude.com/claude-code)