### PR TITLE
ci: switch to npm trusted publishers for OIDC authentication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +27,4 @@ jobs:
         run: yarn build
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Replace NPM_TOKEN secret with OIDC-based trusted publishers
- Add `id-token: write` permission for OIDC authentication
- Use `--provenance` flag for signed provenance statements

## Setup Required
Before merging, configure trusted publishers on npmjs.com:
1. Go to package settings on npmjs.com
2. Under "Publishing access" → "Trusted publishing", link this GitHub repository
3. Configure: `danielma/unsplash-react` repository and workflow file path

## Test plan
- [x] Configure trusted publishers on npmjs.com
- [ ] Merge and verify next release publishes successfully with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)