### PR TITLE
fix(ci): upgrade Node.js to version 22 for npm provenance support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 


### PR DESCRIPTION
## Summary
- Upgrades Node.js from version 20 to version 22 in the release-please workflow

## Rationale
The npm publish action is failing because npm provenance publishing requires:
- Node.js version 22.14.0 or higher
- npm CLI version 11.5.1 or later

This change ensures the workflow meets these minimum requirements for successful publishing with provenance statements.

## Test plan
- [ ] Verify workflow runs successfully on push
- [ ] Confirm npm publish works with provenance flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)