### PR TITLE
fix(ci): upgrade to Node.js 24 for npm 11.5.1+ support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 


### PR DESCRIPTION
## Summary
- Upgrades Node.js from version 22 to version 24 in the release-please workflow

## Rationale
The npm publish action is failing because npm provenance publishing requires npm CLI version 11.5.1 or later. Node 22 was bundling npm 10.9.4, but Node 24 LTS includes npm 11.x by default.

## Test plan
- [ ] Verify workflow runs successfully with Node 24
- [ ] Confirm npm publish works with provenance flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)