### PR TITLE
fix: remove `.js` extension from cjs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "test:cjs": "node test/cjs-compat.cjs",
     "dev": "rollup -c -w",
     "build": "NODE_ENV=production rollup -c",
     "prepare": "yarn build"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.33.0",
     "prettier": "^3.0.0",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollup": "^4.0.0",
     "rollup-plugin-typescript2": "^0.36.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Upload images from unsplash into your app",
   "type": "module",
   "source": "src/index.tsx",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "umd:main": "dist/index.umd.js",
   "types": "dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "typescript": "^5.3.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "test:cjs": "node test/cjs-compat.cjs",
+    "test": "node test/cjs-compat.cjs",
     "dev": "rollup -c -w",
     "build": "NODE_ENV=production rollup -c",
     "prepare": "yarn build"

--- a/test/cjs-compat.cjs
+++ b/test/cjs-compat.cjs
@@ -1,0 +1,16 @@
+// Verifies the CJS build is loadable as CommonJS.
+// Fails with "ReferenceError: exports is not defined" if the package
+// has "type": "module" but the CJS bundle uses a .js extension.
+//
+// intersection-observer is a browser polyfill; stub window/document so it
+// doesn't crash when loaded outside a browser environment.
+global.window = global
+global.document = {}
+
+const UnsplashReact = require("../dist/index.cjs")
+
+console.assert(
+  typeof UnsplashReact.default === "function",
+  "default export should be a function"
+)
+console.log("CJS compat: OK")


### PR DESCRIPTION
### What
Removes `.js` from `"main": "dist/index.cjs.js",`.
Adds a test that reproduces the issue and verifies this fix.

### Why?
After updating to `v0.4.3` (from `v0.3.1`) our front end tests started failing with this error:
```
ReferenceError: exports is not defined
 ❯ ../../node_modules/unsplash-react/dist/index.cjs.js:3:23
      1| 'use strict';
      2| 
      3| Object.defineProperty(exports, '__esModule', { value: true });
       |                       ^
      4| 
      5| var React = require('react');
```


### Notes
I'd be happy to remove the tests and react dev-dependency if you prefer.
The react dev dependency was added for the test.


